### PR TITLE
fix(request): use update_columns:[] on nested target on_conflict (bug-087)

### DIFF
--- a/src/mappers/__tests__/request.test.ts
+++ b/src/mappers/__tests__/request.test.ts
@@ -233,7 +233,11 @@ describe('buildJunctionInserts', () => {
     expect(targetData['id']).toBe('https://w3id.org/okn/i/mint/Economy');
     const targetConflict = category['on_conflict'] as Record<string, unknown>;
     expect(targetConflict['constraint']).toBe('modelcatalog_model_category_pkey');
-    expect(targetConflict['update_columns']).toEqual(['label']);
+    // Link-or-noop semantics: never overwrite columns on existing target rows.
+    // Previous value ['label'] caused null-label cascade (bug-087) when client
+    // sent only `{id}` -- nestedData lacked label and on_conflict overwrote
+    // the existing row's label with NULL.
+    expect(targetConflict['update_columns']).toEqual([]);
   });
 
   it('Test 2: generates UUID-based ID with https prefix when no ID provided', () => {
@@ -341,6 +345,37 @@ describe('buildJunctionInserts', () => {
     // Nested entity data should NOT have is_optional:
     const nestedData = (junctionRow['input'] as Record<string, unknown>)['data'] as Record<string, unknown>;
     expect(nestedData).not.toHaveProperty('is_optional');
+  });
+
+  it('Regression bug-087: linking by string id alone never sets update_columns to overwrite target.label with NULL', () => {
+    const configConfig = getResourceConfig('modelconfigurations')!;
+    const body = { hasInput: ['https://w3id.org/okn/i/mint/existing-ds-id'] };
+    const result = buildJunctionInserts(body, configConfig);
+    const inputs = result['inputs'] as Record<string, unknown>;
+    const data = inputs['data'] as Record<string, unknown>[];
+    const junctionRow = data[0] as Record<string, unknown>;
+    const nestedTarget = junctionRow['input'] as Record<string, unknown>;
+    const nestedData = nestedTarget['data'] as Record<string, unknown>;
+    // Client sent only an id -- nested data must contain only id, no label.
+    expect(Object.keys(nestedData)).toEqual(['id']);
+    expect(nestedData['id']).toBe('https://w3id.org/okn/i/mint/existing-ds-id');
+    // Critical: on_conflict must NOT update label. Updating label with the
+    // missing-from-payload value would null-clobber the existing target row
+    // and trip the not-null constraint on dataset_specification.label.
+    const targetConflict = nestedTarget['on_conflict'] as Record<string, unknown>;
+    expect(targetConflict['update_columns']).toEqual([]);
+  });
+
+  it('Regression bug-087: object-form link with only id likewise produces empty update_columns', () => {
+    const configConfig = getResourceConfig('modelconfigurations')!;
+    const body = { hasInput: [{ id: 'https://w3id.org/okn/i/mint/existing-ds-id' }] };
+    const result = buildJunctionInserts(body, configConfig);
+    const inputs = result['inputs'] as Record<string, unknown>;
+    const data = inputs['data'] as Record<string, unknown>[];
+    const junctionRow = data[0] as Record<string, unknown>;
+    const nestedTarget = junctionRow['input'] as Record<string, unknown>;
+    const targetConflict = nestedTarget['on_conflict'] as Record<string, unknown>;
+    expect(targetConflict['update_columns']).toEqual([]);
   });
 
   it('Test 11: omits is_optional from junction row when isOptional is absent in request body (D-22)', () => {

--- a/src/mappers/request.ts
+++ b/src/mappers/request.ts
@@ -224,7 +224,7 @@ export function buildJunctionInserts(
             data: nestedData,
             on_conflict: {
               constraint: `${targetTable}_pkey`,
-              update_columns: ['label'],
+              update_columns: [],
             },
           },
         };


### PR DESCRIPTION
## Summary
- POST /modelconfigurations, /modelconfigurationsetups, /datasetspecifications with relation fields (hasInput/hasOutput/hasModelCategory/hasPresentation) returned 400 null value in column "label" when the client linked an existing target by id alone.
- buildJunctionInserts emitted on_conflict.update_columns:['label'] on the nested target-entity insert. With nestedData = {id} only, on Hasura PK conflict the existing target row got UPDATE label=NULL and tripped the not-null constraint. Outer junction insert already used update_columns:[]; the inner inconsistency was the bug.
- Switch nested target on_conflict.update_columns to [] for link-or-noop semantics on existing target rows. New target rows still insert with all supplied fields. Renames remain the responsibility of the target's own PUT endpoint.

## Evidence
Reproduction matrix (5 hypotheses, see dynamo-experiment-may/tests/modelconfig_writepaths_results.json):
- H1 minimal POST (no relations): 201
- H2 POST hasInput:[vp_id] string: 400 null label (this bug)
- H3 setup POST id-only objects: 400 null label
- H4 datasetspecifications POST hasPresentation:[vp_id]: 400 null label
- H5 POST with full nested DS objects (label included): 201 — confirms cause: H5 supplies label so the on_conflict update is a no-op

## Test plan
- [x] npm test (vitest): 188 passing
- [x] Updated existing assertion in src/mappers/__tests__/request.test.ts Test 1 (was codifying the bug)
- [x] Added two regressions covering hasInput:["id"] (string form) and [{id}] (object form), each asserting update_columns:[]
- [ ] Live integration: POST /modelconfigurations with hasInput:["<existing DS id>"] returns 201 and GET shows the relation

## Out of scope
PUT path with a VariablePresentation id still hits configuration_input_input_id_fkey because that FK targets dataset_specification. Separate FK type-mismatch issue; clients must pass DS ids, not VP ids.